### PR TITLE
export so they persist for the check in the start script after exec

### DIFF
--- a/templates/default/sv-kafka-run.erb
+++ b/templates/default/sv-kafka-run.erb
@@ -1,16 +1,16 @@
 #!/bin/bash
-SCALA_VERSION="<%= node.kafka.scala_version %>"
-JMX_PORT="<%= node.kafka.jmx_port %>"
+export SCALA_VERSION="<%= node.kafka.scala_version %>"
+export JMX_PORT="<%= node.kafka.jmx_port %>"
 
-KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:<%= node.kafka.config_dir %>/log4j.properties"
-KAFKA_HEAP_OPTS="<%= node.kafka.heap_opts %>"
-KAFKA_GC_LOG_OPTS="<%= node.kafka.gc_log_opts %>"
-KAFKA_OPTS="<%= node.kafka.generic_opts %>"
-KAFKA_JVM_PERFORMANCE_OPTS="<%= node.kafka.jvm_performance_opts %>"
+export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:<%= node.kafka.config_dir %>/log4j.properties"
+export KAFKA_HEAP_OPTS="<%= node.kafka.heap_opts %>"
+export KAFKA_GC_LOG_OPTS="<%= node.kafka.gc_log_opts %>"
+export KAFKA_OPTS="<%= node.kafka.generic_opts %>"
+export KAFKA_JVM_PERFORMANCE_OPTS="<%= node.kafka.jvm_performance_opts %>"
 
-KAFKA_RUN="<%= node.kafka.install_dir %>/bin/kafka-run-class.sh"
-KAFKA_ARGS="<%= @options[:main_class] %>"
-KAFKA_CONFIG="<%= node.kafka.config_dir %>/server.properties"
+export KAFKA_RUN="<%= node.kafka.install_dir %>/bin/kafka-run-class.sh"
+export KAFKA_ARGS="<%= @options[:main_class] %>"
+export KAFKA_CONFIG="<%= node.kafka.config_dir %>/server.properties"
 
 ulimit -c unlimited
 echo "exec chpst -u <%= @options[:user] %> $KAFKA_RUN $KAFKA_ARGS $KAFKA_CONFIG"


### PR DESCRIPTION
The start script that ships with kafka, that we call, check for some things to be set.  We need to export those things here so they persist after the exec.
