### PR TITLE
we never use the port here.

### DIFF
--- a/recipes/_configure.rb
+++ b/recipes/_configure.rb
@@ -43,7 +43,6 @@ if node.kafka.init_style == 'runit'
   runit_service 'kafka' do
     options({
       :main_class => 'kafka.Kafka',
-      :port => node.kafka.broker.port,
       :user => node.kafka.user
     })
     if restart_on_configuration_change?


### PR DESCRIPTION
this may not be set as a result of changes for v9 ssl stuff, but we do not use it in runit code path any way so just remove it. 
